### PR TITLE
Failing test showing non-required fields should allow None.

### DIFF
--- a/tavi/test/unit/fields_test.py
+++ b/tavi/test/unit/fields_test.py
@@ -16,11 +16,21 @@ class BooleanFieldTest(unittest.TestCase):
         self.assertEqual(0, t.errors.count)
 
         t.f = None
-        self.assertEqual(["My Boolean must be a valid boolean"],
-            t.errors.full_messages)
+        # since the field is not required
+        self.assertEqual(0, t.errors.count)
 
         t.f = False
         self.assertEqual(0, t.errors.count)
+
+    def test_required_field(self):
+        class Target(object):
+            f = fields.BooleanField("my_boolean", required=True)
+            errors = Errors()
+
+        t = Target()
+        t.f = None
+
+        self.assertEqual(1, t.errors.count)
 
 class DateTimeFieldTest(unittest.TestCase):
     def test_validates_is_datetime(self):


### PR DESCRIPTION
(Also may be problem in Float, Integer, etc)
