### PR TITLE
Compound unique index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ env
 MANIFEST
 Tavi.egg-info
 .coverage
+.idea

--- a/tavi/documents.py
+++ b/tavi/documents.py
@@ -51,13 +51,10 @@ class Document(BaseDocument):
     def __init__(self, **kwargs):
         self._id = kwargs.pop("_id", None)
         super(Document, self).__init__(**kwargs)
-        for k, v in self._field_descriptors.items():
-            if v.unique:
-                opts = {
-                    "name": "%s_unique_index" % k,
-                    "unique": True
-                }
-                self.__class__.collection.create_index(k, **opts)
+        unique_keys = [k for k, v in self._field_descriptors.items() if v.unique]
+        if len(unique_keys) > 0:
+            self.__class__.collection.create_index([(k, pymongo.ASCENDING) for k in unique_keys],
+                name="%s_unique_index" % "_".join(unique_keys)[:114], unique=True)
 
     @property
     def bson_id(self):

--- a/tavi/test/unit/document_insert_test.py
+++ b/tavi/test/unit/document_insert_test.py
@@ -12,6 +12,9 @@ class Address(EmbeddedDocument):
     created_at = fields.DateTimeField("created_at")
     last_modified_at = fields.DateTimeField("last_modified_at")
 
+class SampleWithCompoundUniqueKey(Document):
+    first_unique_fld = fields.StringField("first_unique_fld", required=True, unique=True)
+    second_unique_fld = fields.StringField("second_unique_fld", required=True, unique=True)
 
 class DocumentInsertTest(unittest.TestCase):
     class Sample(Document):
@@ -202,3 +205,17 @@ class DocumentInsertTest(unittest.TestCase):
             another_sample.errors.full_messages
         )
         self.assertIsNone(another_sample.created_at)
+
+    def test_compound_unique_fields_on_insert(self):
+        compound_key_sample = SampleWithCompoundUniqueKey(first_unique_fld="one", second_unique_fld="two")
+        assert compound_key_sample.save(), compound_key_sample.errors.full_messages
+
+        second_sample = SampleWithCompoundUniqueKey(first_unique_fld="one", second_unique_fld="three")
+        assert second_sample.save(), second_sample.errors.full_messages
+
+        another_sample = SampleWithCompoundUniqueKey(first_unique_fld="one", second_unique_fld="two")
+        self.assertFalse(another_sample.save())
+        self.assertEqual(
+            ["First Unique Fld Second Unique Fld must be unique"],
+            another_sample.errors.full_messages
+        )


### PR DESCRIPTION
A compound unique index should be created when multiple fields are specified as unique in a document.
