### PR TITLE
Fix DuplicateKeyError parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,17 @@ language: python
 python:
   - "2.7"
 before_install:
-  - "sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10"
-  - "echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list"
-  - "sudo apt-get update"
-  - "sudo apt-get install mongodb-org-server"
+  - ./install_mongo.sh
 install: pip install -r requirements.txt
 before_script:
   - "flake8 tavi"
   - "until nc -z localhost 27017; do echo Waiting for MongoDB; sleep 1; done"
 script:  python setup.py nosetests
+env:
+  - "PYMONGO_VERSION='== 2.4.1' MONGO_VERSION=2.6.12"
+  - "PYMONGO_VERSION='>= 2.8.0, < 3.0.0' MONGO_VERSION=2.6.12"
+  - "PYMONGO_VERSION='>= 2.8.0, < 3.0.0' MONGO_VERSION=3.0.11"
+  - "PYMONGO_VERSION='>= 3.2.0, < 4.0.0' MONGO_VERSION=2.6.12"
+  - "PYMONGO_VERSION='>= 3.2.0, < 4.0.0' MONGO_VERSION=3.0.11"
+  - "PYMONGO_VERSION='>= 3.2.0, < 4.0.0' MONGO_VERSION=3.2.6"
+sudo: required

--- a/install_mongo.sh
+++ b/install_mongo.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+case $MONGO_VERSION in
+  2.6.12 )
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 &&
+    echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/mongodb.list
+    sudo apt-get update
+    sudo apt-get install -y mongodb-org-server=$MONGO_VERSION ;;
+  3.0.11 )
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10 &&
+    echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.0 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.0.list
+    sudo apt-get update
+    sudo apt-get install -y mongodb-org-server=$MONGO_VERSION ;;
+  3.2.6 )
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927 &&
+    echo "deb http://repo.mongodb.org/apt/debian wheezy/mongodb-org/3.2 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
+    sudo apt-get update
+    sudo apt-get install -y mongodb-org-server=$MONGO_VERSION ;;
+esac

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 # I prefer Markdown to reStructuredText. PyPi does not. This allows people to
 # install and not get any errors.
+import os
 try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst')
@@ -40,7 +41,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "inflection >= 0.2.0",
-        "pymongo >= 2.4.1"
+        "pymongo {PYMONGO_VERSION}".format(PYMONGO_VERSION=os.getenv("PYMONGO_VERSION", ">= 2.4.1"))
     ] + test_requirements,
     tests_require=test_requirements,
     test_suite="nose_collector"

--- a/tavi/base/documents.py
+++ b/tavi/base/documents.py
@@ -37,7 +37,7 @@ def set_field_attr(cls, field, value):
             getattr(cls, field).append(field_descriptor._type(**item))
         return
 
-    if None == value:
+    if value is None:
         value = field_descriptor.default
 
     if isinstance(value, dict):

--- a/tavi/base/fields.py
+++ b/tavi/base/fields.py
@@ -39,7 +39,7 @@ class BaseField(object):
         return getattr(instance, self.attribute_name)
 
     def __set__(self, instance, value):
-        if None == value and self.required and self.default:
+        if value is None and self.required and self.default:
             value = self.default
         self.validate(instance, value)
         setattr(instance, self.attribute_name, value)
@@ -55,7 +55,7 @@ class BaseField(object):
 
         """
         instance.errors.clear(self.name)
-        if self.required and None == value:
+        if self.required and value is None:
             instance.errors.add(self.name, "is required")
 
         if self.choices and value not in self.choices:

--- a/tavi/documents.py
+++ b/tavi/documents.py
@@ -60,8 +60,8 @@ class Document(BaseDocument):
         if len(unique_keys) > 0:
             key_pairs = [(k, pymongo.ASCENDING) for k in unique_keys]
             max_index_name_length = self.__MAX_NAMESPACE_SIZE__ - \
-                len(".$" + self.__class__.collection.full_name
-                    + self.__UNIQUE_INDEX_SUFFIX__)
+                len(".$" + self.__class__.collection.full_name +
+                    self.__UNIQUE_INDEX_SUFFIX__)
 
             name = "_".join(unique_keys)[:max_index_name_length] + \
                 self.__UNIQUE_INDEX_SUFFIX__

--- a/tavi/fields.py
+++ b/tavi/fields.py
@@ -32,7 +32,7 @@ class DateTimeField(BaseField):
         """Validates the field."""
         super(DateTimeField, self).validate(instance, value)
 
-        if None != value and not isinstance(value, datetime.datetime):
+        if value is not None and not isinstance(value, datetime.datetime):
             instance.errors.add(self.name, "must be a valid date and time")
 
 
@@ -48,27 +48,27 @@ class FloatField(BaseField):
     def __init__(self, name, min_value=None, max_value=None, **kwargs):
         super(FloatField, self).__init__(name, **kwargs)
 
-        self.min_value = None if None == min_value else float(min_value)
-        self.max_value = None if None == max_value else float(max_value)
+        self.min_value = None if min_value is None else float(min_value)
+        self.max_value = None if max_value is None else float(max_value)
 
     def validate(self, instance, value):
         """Validates the field."""
         super(FloatField, self).validate(instance, value)
 
-        if None != value:
+        if value is not None:
             if isinstance(value, int):
                 value = float(value)
 
             if not isinstance(value, float):
                 instance.errors.add(self.name, "must be a float")
 
-            if not None == self.min_value and value < self.min_value:
+            if self.min_value is not None and value < self.min_value:
                 instance.errors.add(
                     self.name,
                     "is too small (minimum is %s)" % self.min_value
                 )
 
-            if not None == self.max_value and value > self.max_value:
+            if self.max_value is not None and value > self.max_value:
                 instance.errors.add(
                     self.name,
                     "is too big (maximum is %s)" % self.max_value
@@ -87,24 +87,24 @@ class IntegerField(BaseField):
     def __init__(self, name, min_value=None, max_value=None, **kwargs):
         super(IntegerField, self).__init__(name, **kwargs)
 
-        self.min_value = None if None == min_value else int(min_value)
-        self.max_value = None if None == max_value else int(max_value)
+        self.min_value = None if min_value is None else int(min_value)
+        self.max_value = None if max_value is None else int(max_value)
 
     def validate(self, instance, value):
         """Validates the field."""
         super(IntegerField, self).validate(instance, value)
 
-        if None != value:
+        if value is not None:
             if not isinstance(value, int):
                 instance.errors.add(self.name, "must be a integer")
 
-            if not None == self.min_value and value < self.min_value:
+            if self.min_value is not None and value < self.min_value:
                 instance.errors.add(
                     self.name,
                     "is too small (minimum is %s)" % self.min_value
                 )
 
-            if not None == self.max_value and value > self.max_value:
+            if self.max_value is not None and value > self.max_value:
                 instance.errors.add(
                     self.name,
                     "is too big (maximum is %s)" % self.max_value

--- a/tavi/test/unit/serialization_test.py
+++ b/tavi/test/unit/serialization_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 import datetime
+import json
 from tavi import fields
 from tavi.documents import Document
 
@@ -20,17 +21,15 @@ class SerializationTest(unittest.TestCase):
             sold_on=datetime.datetime(2013, 8, 25, 22, 24, 0)
         )
 
-        expected = (
-            '{'
-            '"id": null, '
-            '"sold_on": {"$date": 1377469440000}, '
-            '"price": 9.99, '
-            '"name": "Widget", '
-            '"quantity": 3'
-            '}'
-        )
+        expected = {
+            "id": None,
+            "sold_on": {"$date": 1377469440000},
+            "price": 9.99,
+            "name": "Widget",
+            "quantity": 3
+        }
 
-        self.assertEqual(expected, t.to_json())
+        self.assertDictEqual(expected, json.loads(t.to_json()))
 
     def test_serialize_only_specified_fields_to_json(self):
         t = self.Target(
@@ -40,18 +39,18 @@ class SerializationTest(unittest.TestCase):
             sold_on=datetime.datetime(2013, 8, 25, 22, 24, 0)
         )
 
-        expected = (
-            '{'
-            '"id": null, '
-            '"price": 9.99, '
-            '"name": "Widget", '
-            '"quantity": 3'
-            '}'
-        )
+        expected = {
+            "id": None,
+            "price": 9.99,
+            "name": "Widget",
+            "quantity": 3
+        }
 
-        self.assertEqual(
+        actual = t.to_json(fields=['bson_id', 'name', 'price', 'quantity'])
+
+        self.assertDictEqual(
             expected,
-            t.to_json(fields=['bson_id', 'name', 'price', 'quantity'])
+            json.loads(actual)
         )
 
     def test_deserialize_from_json(self):


### PR DESCRIPTION
Specifically when using pymongo 3.2.X and mongodb 3.2.X, the error
message format has changed and needs a different regex to parse out the
offending index.
